### PR TITLE
fix: make snapshot tests timezone-independent

### DIFF
--- a/src/Intellenum/MemberGeneration.cs
+++ b/src/Intellenum/MemberGeneration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -111,9 +111,10 @@ public static class MemberGeneration
                 if(propertyValue is string s)
                 {
                     var parsed = DateTimeOffset.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    var utcParsed = new DateTimeOffset(parsed.DateTime, TimeSpan.Zero);
 
                     return new(true,
-                        $@"global::System.DateTimeOffset.Parse(""{parsed:O}"", null, global::System.Globalization.DateTimeStyles.RoundtripKind)");
+                        $@"global::System.DateTimeOffset.Parse(""{utcParsed:O}"", null, global::System.Globalization.DateTimeStyles.RoundtripKind)");
                 }
 
                 if(propertyValue is long l)


### PR DESCRIPTION
This PR aims to fix an issue I observed when running the snapshot test suite where the valid ISO8601 tests failed due to the snapshot being UTC+0, but my run producing UTC+13 (my local TZ). ~~I've also noticed this with Vogen before so I'll PR there too~~ it's no longer an issue with Vogen.

FYI there's some weird snapshot generation happening here - whenever I run the suite it seems to regenerate all of the verification files in different paths. I'll investigate - but I suspect the directory needs to be explicitly set.