### PR TITLE
feat: use ReadOnlySpan<char> over strings for string-accepting methods

### DIFF
--- a/src/Intellenum/Generators/ClassGenerator.cs
+++ b/src/Intellenum/Generators/ClassGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Intellenum.Generators.Snippets;
+using Intellenum.Generators.Snippets;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Intellenum.Generators;
@@ -13,6 +13,7 @@ public class ClassGenerator : IGenerateSourceCode
         
         return $@"
 using Intellenum;
+using System;
 {Util.TryWriteNamespaceIfSpecified(item)}
 
 {Util.WriteStartNamespace(item.FullNamespace)}

--- a/src/Intellenum/Generators/Snippets/ForConstantUnderlying/FromNameRelatedMethods.cs
+++ b/src/Intellenum/Generators/Snippets/ForConstantUnderlying/FromNameRelatedMethods.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Intellenum.Generators.Snippets.ForConstantUnderlying;
@@ -15,7 +15,7 @@ public static class FromNameRelatedMethods
         /// </summary>
         /// <param name=""name"">The name.</param>
         /// <returns>The matching enum, or an exception.</returns>
-        public static {className} FromName(string name)
+        public static {className} FromName(ReadOnlySpan<char> name)
         {{
             {GenerateFromNameImplementation(item)}
         }}
@@ -26,13 +26,13 @@ public static class FromNameRelatedMethods
         /// <param name=""name"">The name.</param>
         /// <returns>The matching enum, or an exception.</returns>
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static bool TryFromName(string name, out {className} member)
+        public static bool TryFromName(ReadOnlySpan<char> name, out {className} member)
         {{
             {GenerateTryFromNameImplementation(item)}
         }}
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static bool IsNamedDefined(string name)
+        public static bool IsNamedDefined(ReadOnlySpan<char> name)
         {{
             {GenerateIsNameDefinedImplementation()}
         }}

--- a/src/Intellenum/Generators/Snippets/ForNonConstantUnderlying/FromNameRelatedMethods.cs
+++ b/src/Intellenum/Generators/Snippets/ForNonConstantUnderlying/FromNameRelatedMethods.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Intellenum.Generators.Snippets.ForNonConstantUnderlying;
 
@@ -14,7 +14,7 @@ public static class FromNameRelatedMethods
         /// </summary>
         /// <param name=""name"">The name.</param>
         /// <returns>The matching enum, or an exception.</returns>
-        public static {className} FromName(string name)
+        public static {className} FromName(ReadOnlySpan<char> name)
         {{
             {GenerateFromNameImplementation(item)}
         }}
@@ -25,13 +25,13 @@ public static class FromNameRelatedMethods
         /// <param name=""name"">The name.</param>
         /// <returns>The matching enum, or an exception.</returns>
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static bool TryFromName(string name, out {className} member)
+        public static bool TryFromName(ReadOnlySpan<char> name, out {className} member)
         {{
             {GenerateTryFromNameImplementation()}
         }}
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static bool IsNamedDefined(string name)
+        public static bool IsNamedDefined(ReadOnlySpan<char> name)
         {{
             {GenerateIsNameDefinedImplementation()}
         }}

--- a/src/Intellenum/Util.cs
+++ b/src/Intellenum/Util.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Intellenum.Generators.Conversions;
@@ -208,9 +208,14 @@ causes Rider's debugger to crash.
 
     public static string TryWriteNamespaceIfSpecified(VoWorkItem item)
     {
-        if (!string.IsNullOrEmpty(item.UnderlyingType.FullNamespace()))
-            return "using " + item.UnderlyingType.FullNamespace() + ";";
+        var fullNamespace = item.UnderlyingType.FullNamespace();
 
-        return string.Empty;
+        // Should ignore using of System namespace as it's provided externally
+        if (string.IsNullOrEmpty(fullNamespace) || fullNamespace == "System")
+        {
+            return string.Empty;
+        }
+
+        return $"using {fullNamespace};";
     }
 }


### PR DESCRIPTION
This PR aims to implement #31 by swapping out `string` parameters for the listed string-accepting methods with `ReadOnlySpan<char>`.

Members identified across both constant & non-constant generators:
 - `FromName(string)`
 - `TryFromName(string, T)`
 - `IsNameDefined(string)`

I should note that the implementation of the non-constant `TryFromName` method as it was using `Dictionary`'s `TryGetValue` which does not accept a `ReadOnlySpan<char>`. Instead, I've used a `foreach` loop (for now, see TODO) to check each element in the key list. Not ideal, but it works for now and removes a secondary string allocation.

TODO:
 - [ ] Benchmark the `foreach` loop (I'd like to potentially use Memorymarshall and Unsafe but KeyCollection is weird)
 - [ ] Benchmark this change against mainline (after above item)