### PR TITLE
Generate const fields for applicable types

### DIFF
--- a/src/Intellenum/Generators/ClassGenerator.cs
+++ b/src/Intellenum/Generators/ClassGenerator.cs
@@ -26,6 +26,8 @@ using System;
         global::System.IComparable, 
         global::System.IComparable<{className}> 
     {{
+        {MemberGeneration.GenerateConstValuesIfPossible(item)}
+
         {Util.GenerateLazyLookupsIfNeeded(item)}
 
 #if DEBUG    

--- a/src/Intellenum/MemberGeneration.cs
+++ b/src/Intellenum/MemberGeneration.cs
@@ -199,6 +199,23 @@ public static class MemberGeneration
                 $"Member '{propertyName}' has a value type '{propertyValue.GetType()}' of '{propertyValue}' which cannot be converted to the underlying type of '{underlyingType}' - {e.Message}");
         }
     }
+    
+    public static string GenerateConstValuesIfPossible(VoWorkItem item)
+    {
+        if (!item.IsConstant || item.MemberProperties.Count == 0)
+        {
+            return string.Empty;
+        }
+        
+        StringBuilder sb = new StringBuilder("// const fields...");
+        sb.AppendLine();
+        foreach (var memberProperties in item.MemberProperties)
+        {
+            sb.AppendLine($"public const {item.UnderlyingTypeFullName} {memberProperties.FieldName}Const = {memberProperties.ValueAsText};");
+        }
+        
+        return sb.ToString();
+    }
 
     public static string GeneratePrivateConstructionInitialisationIfNeeded(VoWorkItem item)
     {

--- a/src/Intellenum/MemberGeneration.cs
+++ b/src/Intellenum/MemberGeneration.cs
@@ -211,7 +211,7 @@ public static class MemberGeneration
         sb.AppendLine();
         foreach (var memberProperties in item.MemberProperties)
         {
-            sb.AppendLine($"public const {item.UnderlyingTypeFullName} {memberProperties.FieldName}Const = {memberProperties.ValueAsText};");
+            sb.AppendLine($"public const {item.UnderlyingTypeFullName} {memberProperties.FieldName}Value = {memberProperties.ValueAsText};");
         }
         
         return sb.ToString();


### PR DESCRIPTION
Closes #125 

This generates const fields for applicable types, for example:

```cs
public partial class CustomerType : 
    global::System.IEquatable<CustomerType>, 
    global::System.IComparable, 
    global::System.IComparable<CustomerType> 
{
    // const fields...
    public const System.Int32 NormalValue = 0;
    public const System.Int32 GoldValue = 1;
    public const System.Int32 DiamondValue = 2;
```

This allows us to write:

```cs
public partial class CustomerType
{
    public string GetIcon()
    {
        return Value switch
        {
            NormalValue => "🟢",
            GoldValue => "🟡",
            DiamondValue => "🔵",
            _ => throw new UnreachableException(),
        };
    }
}
```

instead of:

```cs
public partial class CustomerType
{
    public string GetIcon()
    {
        if (this == Normal)
            return "🟢";
    
        if (this == Gold)
            return "🟡";
    
        if (this == Diamond)
            return "🔵";

        throw new UnreachableException();
    }
}
```

The new generator method ignores types that are not constants, such as:

```
public record class Planet(string Colour, int CircumferenceInMiles)
```

It would probably be nice to have a test that explicitly validates that these `const` fields are _only_ generated for [primitives](https://learn.microsoft.com/en-us/dotnet/api/system.type.isprimitive?view=net-8.0&redirectedfrom=MSDN#remarks), strings, and decimals.